### PR TITLE
add GNOME 44 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
     "40",
     "41",
     "42",
-    "43"
+    "43",
+    "44"
   ],
   "url" : "https://github.com/MedaiP90/gnome-sur-clock",
   "uuid": "Sur_Clock@medaip90.com",


### PR DESCRIPTION
tested on Fedora 38 beta, works

![Screenshot from 2023-03-29 22-58-39](https://user-images.githubusercontent.com/53501005/228717227-c80960e1-ad7c-49bd-9ba5-601146b48f22.png)
